### PR TITLE
Added default version for mysql image for WP

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
         command: "sh wp.sh"
 
     db:
-        image: mysql
+        image: mysql:5.7
         ports:
             - 3306:3306
         environment:


### PR DESCRIPTION
While using the latest image of mysql there was an error while authenticating using mysql::__construct();

```
docker wordpress Warning: mysqli::__construct(): (HY000/2002): Connection refused in - on line 22
```